### PR TITLE
Update `atproto` and enforce newer `pydantic`, where compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [build-system]
+# note: this package can't be *built* on py3.8 due to setuptools compatibility,
+# but it should *install* just fine
 requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -41,8 +43,15 @@ keywords = [
 requires-python = ">=3.8, <3.14"  # Should be synced with `atproto` below
 dependencies = [
     "sopel>=8.0",
-    # pin `atproto`: upstream says <1.0 can have breaking changes any time
-    "atproto==0.0.62",  # Should be synced with `requires-python` above
+    # pin `atproto`: upstream says <1.0 can have breaking changes any time;
+    # also note the python version conditionals here and keep in sync with
+    # 'requires-python' above as things evolve
+    "atproto==0.0.62; python_version < '3.9'",  # last release to support py3.8
+    "atproto==0.0.63; python_version >= '3.9'",
+    # pydantic 2.11 dropped py3.8 support but older versions will still work,
+    # at the cost of slower startup times
+    "pydantic~=2.10.0; python_version < '3.9'",
+    "pydantic>=2.11; python_version >= '3.9'",
 ]
 
 [project.urls]


### PR DESCRIPTION
This also resolves the little note in [`sopel-bsky` 0.1.2](https://github.com/dgw/sopel-bsky/releases/tag/v0.1.2) regarding Python 3.14. `atproto==0.0.63` supports it now.

A lot of projects have dropped Python 3.8 at this point, but if possible it's ideal for this plugin to have newer versions of `pydantic` in particular due to performance improvements in v2.11.x.

Python 3.8 can't benefit from that, but let's at least make sure it gets the newest compatible `pydantic` (2.10.x) and the last version of `atproto` that's supported.

This is half of #5; the other half will be a bit more complicated, trying to defer loading of the `atproto` machinery until after bot startup so it doesn't make Sopel take ~10s or longer to start on a middle-of-the-road VPS VM.